### PR TITLE
Update example to include full plugin name

### DIFF
--- a/libs/sq-server-commons/src/components/tutorials/jenkins/buildtool-steps/Maven.tsx
+++ b/libs/sq-server-commons/src/components/tutorials/jenkins/buildtool-steps/Maven.tsx
@@ -29,7 +29,7 @@ function jenkinsfileSnippet(projectKey: string, projectName: string) {
   stage('SonarQube Analysis') {
     def mvn = tool 'Default Maven';
     withSonarQubeEnv() {
-      sh "\${mvn}/bin/mvn clean verify sonar:sonar -Dsonar.projectKey=${projectKey} -Dsonar.projectName='${projectName}'"
+      sh "\${mvn}/bin/mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=${projectKey} -Dsonar.projectName='${projectName}'"
     }
   }
 }`;


### PR DESCRIPTION
This is in link with the documentation https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven and to avoid the use of sonar:sonar which should start to be deprecated.