### PR TITLE
feat: add configurable global UI banner visibility setting

### DIFF
--- a/apps/sq-server/src/main/js/app/components/__tests__/UpdateNotification-it.tsx
+++ b/apps/sq-server/src/main/js/app/components/__tests__/UpdateNotification-it.tsx
@@ -31,6 +31,7 @@ import { renderComponent } from '~sq-server-commons/helpers/testReactTestingUtil
 import { AppState } from '~sq-server-commons/types/appstate';
 import { EditionKey } from '~sq-server-commons/types/editions';
 import { Permissions } from '~sq-server-commons/types/permissions';
+import { GlobalSettingKeys } from '~sq-server-commons/types/settings';
 import { ProductNameForUpgrade } from '~sq-server-commons/types/system';
 import { CurrentUser } from '~sq-server-commons/types/users';
 import { UpdateNotification } from '../update-notification/UpdateNotification';
@@ -69,10 +70,52 @@ describe('when running SQS', () => {
     expect(ui.updateMessage().query()).not.toBeInTheDocument();
   });
 
-  it('should not render update notification if user is not admin', () => {
-    renderUpdateNotification(undefined, { permissions: { global: [] } });
+  it('should not render update notification for non-admin when visibility is ADMINS_ONLY', () => {
+    renderUpdateNotification(
+      undefined,
+      { permissions: { global: [] } },
+      {
+        settings: { [GlobalSettingKeys.BannersVisibility]: 'ADMINS_ONLY' },
+      },
+    );
     expect(getSystemUpgrades).not.toHaveBeenCalled();
     expect(ui.updateMessage().query()).not.toBeInTheDocument();
+  });
+
+  it('should not render update notification when visibility is DISABLED', () => {
+    renderUpdateNotification(undefined, undefined, {
+      settings: { [GlobalSettingKeys.BannersVisibility]: 'DISABLED' },
+    });
+    expect(getSystemUpgrades).not.toHaveBeenCalled();
+    expect(ui.updateMessage().query()).not.toBeInTheDocument();
+  });
+
+  it('should not render update notification when visibility is DISABLED even for admins', () => {
+    renderUpdateNotification(undefined, undefined, {
+      settings: { [GlobalSettingKeys.BannersVisibility]: 'DISABLED' },
+    });
+    expect(getSystemUpgrades).not.toHaveBeenCalled();
+    expect(ui.updateMessage().query()).not.toBeInTheDocument();
+  });
+
+  it('should render update notification for non-admin when visibility is ALL', async () => {
+    jest.mocked(getSystemUpgrades).mockResolvedValue({
+      upgrades: [{ ...SQSUpgrade, version: '10.6.0' }],
+      latestLTA: '9.9',
+      updateCenterRefresh: '',
+      installedVersionActive: true,
+    });
+    renderUpdateNotification(
+      undefined,
+      { permissions: { global: [] } },
+      {
+        settings: { [GlobalSettingKeys.BannersVisibility]: 'ALL' },
+      },
+    );
+    expect(getSystemUpgrades).toHaveBeenCalled();
+    expect(
+      await ui.updateMessage(`admin_notification.update.${UpdateUseCase.NewVersion}`).find(),
+    ).toBeInTheDocument();
   });
 
   it('should not render update notification if no upgrades', () => {

--- a/apps/sq-server/src/main/js/app/components/update-notification/UpdateNotification.tsx
+++ b/apps/sq-server/src/main/js/app/components/update-notification/UpdateNotification.tsx
@@ -25,6 +25,7 @@ import { hasGlobalPermission } from '~sq-server-commons/helpers/users';
 import { useSystemUpgrades } from '~sq-server-commons/queries/system';
 import { EditionKey } from '~sq-server-commons/types/editions';
 import { Permissions } from '~sq-server-commons/types/permissions';
+import { GlobalSettingKeys } from '~sq-server-commons/types/settings';
 import { isLoggedIn } from '~sq-server-commons/types/users';
 import { parseVersion } from '~sq-server-commons/utils/update-notification-helpers';
 import { SQCBUpdateBanners } from './SQCBUpdateBanners';
@@ -38,8 +39,11 @@ export function UpdateNotification({ isGlobalBanner }: Readonly<Props>) {
   const appState = useAppState();
   const { currentUser } = useCurrentUser();
 
+  const isAdmin = isLoggedIn(currentUser) && hasGlobalPermission(currentUser, Permissions.Admin);
+  const visibility = appState.settings[GlobalSettingKeys.BannersVisibility] ?? 'ADMINS_ONLY';
+
   const canUserSeeNotification =
-    isLoggedIn(currentUser) && hasGlobalPermission(currentUser, Permissions.Admin);
+    visibility !== 'DISABLED' && isLoggedIn(currentUser) && (visibility === 'ALL' || isAdmin);
 
   const parsedVersion = parseVersion(appState.version);
 

--- a/libs/sq-server-commons/src/types/settings.ts
+++ b/libs/sq-server-commons/src/types/settings.ts
@@ -48,6 +48,7 @@ export const enum SettingsKey {
 export enum GlobalSettingKeys {
   AnnouncementHTMLMessage = 'sonar.announcement.htmlMessage',
   AnnouncementMessage = 'sonar.announcement.message',
+  BannersVisibility = 'sonar.ui.banners.visibility',
   DeveloperAggregatedInfoDisabled = 'sonar.developerAggregatedInfo.disabled',
   DisplayAnnouncementMessage = 'sonar.announcement.displayMessage',
   EnableGravatar = 'sonar.lf.enableGravatar',


### PR DESCRIPTION
## What problem does this solve?

Administrators have no way to control who sees global update/upgrade notification banners. This adds a configurable setting to give admins that control.

## What does this change?

Adds a new setting `sonar.ui.banners.visibility` that controls who sees global update/upgrade notification banners.

| Value | Behaviour |
|---|---|
| `ALL` | All logged-in users see update/upgrade banners |
| `ADMINS_ONLY` (default) | Only users with global Admin permission see banners |
| `DISABLED` | No users see banners, and the system upgrades API call is skipped entirely |

## Files changed

- `libs/sq-server-commons/src/types/settings.ts` — adds `BannersVisibility` to `GlobalSettingKeys`
- `apps/sq-server/src/main/js/app/components/update-notification/UpdateNotification.tsx` — reads the setting and gates visibility accordingly
- `apps/sq-server/src/main/js/app/components/__tests__/UpdateNotification-it.tsx` — adds tests covering all three modes

> **Note:** The backend counterpart (property registration in `CorePropertyDefinitions` and exposure via `api/navigation/global`) is in a separate PR against the [sonarqube](https://github.com/SonarSource/sonarqube/pull/3435) repository.